### PR TITLE
Typo fix and explicit overflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,4 @@
-[root]
+[[package]]
 name = "strtod"
 version = "0.0.1"
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+
+[package]
+name = "strtod-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.strtod]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_target_1"
+path = "fuzz_targets/fuzz_target_1.rs"

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate strtod;
+
+fuzz_target!(|data: &[u8]| {
+    std::str::from_utf8(data).map(|s| strtod::strtod(s));
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ impl Parser {
 					c = s.peek();
 					
 					while c >= C0 && c <= C9 {
-						L = L * 10 + c - C0;
+						L = u32::wrapping_sub(u32::wrapping_add(u32::wrapping_mul(L, 10), c), C0);
 						
 						s.bump();
 						c = s.peek();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,7 +580,7 @@ impl Parser {
 	 				aadj1.d = 1_f64;
 	 			} else if self.rv.word1() != 0 || self.rv.word0() & Bndry_mask != 0 {
 	 				if self.rv.word1() == Tiny1 && self.rv.word0() == 0 {
-	 					self.rv.d == 0_f64;
+	 					self.rv.d = 0_f64;
 	 					return true;
 	 				}
 	 				


### PR DESCRIPTION
Fixes pvginkel/strtod#3

I have splitted this into 2 PRs:

- [x] #9 
- [x] #8 

## Summary by Sourcery

Fix a typo in the code and implement explicit wrapping arithmetic to handle overflows. Introduce fuzz testing to ensure robustness of the strtod function.

Bug Fixes:
- Correct a typo in the code where '==' was used instead of '=' for assignment.

Enhancements:
- Use explicit wrapping arithmetic operations to handle potential overflows in calculations.

Tests:
- Add a fuzz testing setup using cargo-fuzz to test the strtod function with various inputs.