### PR TITLE
fix typo and explicit overflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ impl Parser {
                     c = s.peek();
 
                     while c >= C0 && c <= C9 {
-                        L = L * 10 + c - C0;
+                        L = u32::wrapping_sub(u32::wrapping_add(u32::wrapping_mul(L, 10), c), C0);
 
                         s.bump();
                         c = s.peek();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,7 +590,7 @@ impl Parser {
                     aadj1.d = 1_f64;
                 } else if self.rv.word1() != 0 || self.rv.word0() & Bndry_mask != 0 {
                     if self.rv.word1() == Tiny1 && self.rv.word0() == 0 {
-                        self.rv.d == 0_f64;
+                        self.rv.d = 0_f64;
                         return true;
                     }
 


### PR DESCRIPTION
- **Fix comparison typo**
- **Change to explicit wrapping arithmetic**

## Summary by Sourcery

Fix a typo in a comparison operation and change arithmetic operations to use explicit wrapping methods to handle overflow.

Bug Fixes:
- Fix a typo in a comparison operation that incorrectly used '==' instead of '='.

Enhancements:
- Change arithmetic operations to use explicit wrapping methods to handle overflow.